### PR TITLE
Better Strings and Updated Readme

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,5 @@ repository = "https://github.com/Teh-Bobo/unicode-title-case"
 description = "A crate to add Unicode titlecase options to chars and strings"
 
 [features]
-default = ["strings"]
+default = ["std"]
 std = []
-strings = ["std"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Unicode Titlecase
+
 Unicode titlecasing operations for chars and strings. The crate supports has additional
 functionality to support the TR/AZ locales.
+---
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/Teh-Bobo/unicode-title-case/Rust)](https://github.com/Teh-Bobo/unicode-title-case/actions)
+[![docs.rs](https://img.shields.io/docsrs/unicode_titlecase)](https://docs.rs/st_ring_buffer/1.1.0/unicode_titlecase/)
+![Crates.io](https://img.shields.io/crates/l/unicode_titlecase)
+[![Crates.io](https://img.shields.io/crates/v/unicode_titlecase)](https://crates.io/crates/unicode_titlecase)
+![](https://img.shields.io/badge/-no__std-green)
+![](https://img.shields.io/badge/-forbid__unsafe-green)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Unicode Titlecase
 Unicode titlecasing operations for chars and strings. The crate supports has additional
-functionality to support the TR/AZ locale.
+functionality to support the TR/AZ locales.
 
 ## Installation
 
@@ -14,8 +14,7 @@ unicode_titlecase = "1.1.0"
 ## Features
 
 This crate is no_std capable. ```std``` is used for
-```std::Display``` on the iterators and for the "strings" feature. The "strings" feature
-enables functions that operation on Rust ```Strings```.
+```std::Display``` on the iterators, allowing the usage of ```to_string()```.
 
 ## Usage
 
@@ -44,7 +43,7 @@ assert_eq!('ﬄ'.to_titlecase().to_string(), "Ffl");
 
 ### Strings
 
-A similar trait is defined on ```str``` if the "strings" feature is enabled (by default). This
+A similar trait is defined on ```str```. This
 will titlecase the first char of the string, leave the rest unchanged, and return a newly
 allocated ```String```.
 
@@ -65,6 +64,41 @@ assert_eq!("ABC".to_titlecase_lower_rest(), "Abc");
 assert_eq!("ǄǄ".to_titlecase_lower_rest(), "ǅǆ");
 assert_eq!("ﬄabc".to_titlecase_lower_rest(), "Fflabc");
 ```
+
+### Testing a char or str
+
+To see if the char is already titlecase, ```is_titlecase``` is provided:
+
+```rust
+use unicode_titlecase::TitleCase;
+assert!('A'.is_titlecase());
+assert!('ǅ'.is_titlecase());
+assert!('İ'.is_titlecase());
+
+assert!(!'a'.is_titlecase());
+assert!(!'Ǆ'.is_titlecase());
+assert!(!'ﬄ'.is_titlecase());
+```
+
+To test if a str is already titlecase, two options are provided. The first, ```starts_titlecase```
+returns true if the first character is titlecased--ignoring the rest of the str. The second
+```starts_titlecase_rest_lower``` only returns true if the first char is titlecase and the rest
+of the str is lowercase.
+
+```rust
+use unicode_titlecase::StrTitleCase;
+assert!("Abc".starts_titlecase());
+assert!("ABC".starts_titlecase());
+assert!(!"abc".starts_titlecase());
+
+assert!("Abc".starts_titlecase_rest_lower());
+assert!("İbc".starts_titlecase_rest_lower());
+assert!(!"abc".starts_titlecase_rest_lower());
+assert!(!"ABC".starts_titlecase_rest_lower());
+assert!(!"İİ".starts_titlecase_rest_lower());
+```
+
+All testing functions work the same regardless of locale.
 
 ### Locale
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,9 +7,11 @@
 #![deny(rustdoc::missing_doc_code_examples)]
 #![deny(unsafe_code)]
 
-use core::fmt::Write;
+extern crate alloc;
+
+use alloc::string::String;
+use core::fmt::{Debug, Formatter, Write};
 use core::iter::FusedIterator;
-use std::fmt::{Debug, Formatter};
 
 include!(concat!(env!("OUT_DIR"), "/casing.rs"));
 
@@ -173,7 +175,6 @@ impl TitleCase for char {
     }
 }
 
-#[cfg(feature = "strings")]
 /// Trait to add titlecase operations to Strings and string slices. Both locale agnostic and TR/AZ
 /// versions of the functions are supplied.
 pub trait StrTitleCase {
@@ -283,7 +284,6 @@ pub trait StrTitleCase {
     fn starts_titlecase_rest_lower(&self) -> bool;
 }
 
-#[cfg(feature = "strings")]
 impl StrTitleCase for str {
     fn to_titlecase(&self) -> String {
         let mut iter = self.chars();


### PR DESCRIPTION
Revamped the string import, removing the unneeded "String" feature. Moved all the strings to use alloc instead of std, making the string features no_std.

Updated the readme to reflect this change and the changes from #2 and added shields.