### PR TITLE
Fix build status badge according to badges/shields#8671

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Unicode titlecasing operations for chars and strings. The crate supports additional
 functionality for the TR/AZ locales.
 ---
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/Teh-Bobo/unicode-title-case/Rust)](https://github.com/Teh-Bobo/unicode-title-case/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/Teh-Bobo/unicode-title-case/rust.yml?branch=master)](https://github.com/Teh-Bobo/unicode-title-case/actions)
 [![docs.rs](https://img.shields.io/docsrs/unicode_titlecase)](https://docs.rs/unicode_titlecase/latest/unicode_titlecase/)
 ![Crates.io](https://img.shields.io/crates/l/unicode_titlecase)
 [![Crates.io](https://img.shields.io/crates/v/unicode_titlecase)](https://crates.io/crates/unicode_titlecase)


### PR DESCRIPTION
According to https://github.com/badges/shields/issues/8671, the badge img src needed to be updated.

| Before | After |
| --- | --- |
| <img width="391" alt="image" src="https://github.com/badges/shields/assets/12410942/0b5ebfa3-db4f-41ff-9bed-3672ffe05a4c"> | <img width="302" alt="image" src="https://github.com/badges/shields/assets/12410942/008aa38a-57d1-4d47-b609-1ba8fc76b8b2"> |